### PR TITLE
CLI: update file transfer progress to refresh in the same line (fixes #3)

### DIFF
--- a/src/main/java/com/makaty/code/Client/Controllers/DataController.java
+++ b/src/main/java/com/makaty/code/Client/Controllers/DataController.java
@@ -121,12 +121,12 @@ public class DataController {
 
                 // Optional: progress logging
                 double progress = (100.0 * loadedBytes) / size;
-                LoggerManager.getInstance().info(String.format("Progress: %.2f%%", progress));
+                LoggerManager.getInstance().info("@progress " + String.format("Progress: %.2f%%", progress));
             }
         }
 
-
-        LoggerManager.getInstance().info(String.format("File ['%s'] received.\n", fileName));
+        LoggerManager.getInstance().info("@progress:end");
+        LoggerManager.getInstance().info(String.format("File ['%s'] received.", fileName));
     }
 
     private boolean validateAllDirectories(String uri) {

--- a/src/main/java/com/makaty/code/clientCLI/ClientCLILogger.java
+++ b/src/main/java/com/makaty/code/clientCLI/ClientCLILogger.java
@@ -27,6 +27,17 @@ public class ClientCLILogger implements ClientLogger {
 
     @Override
     synchronized public void info(String message) {
+        if (message.startsWith("@progress ")) {
+            String cleanMessage = message.substring(10);
+            System.out.print("\r\u001B[2K[-]: " + cleanMessage);
+            System.out.flush();
+            return;
+        }
+        if ("@progress:end".equals(message)) {
+            System.out.println();
+            System.out.flush();
+            return;
+        }
         reader.printAbove("[-]: " + message);
     }
 


### PR DESCRIPTION
This PR updates the file transfer progress display in the FTP client so that it refreshes in the same console line instead of printing multiple lines.
It replaces the previous LoggerManager.info() logging (used for progress updates) with System.out.print("\r...") and System.out.flush() for smoother, real-time output.
A final println() ensures that the next log and user prompt appear cleanly on a new line.
Other log messages still use LoggerManager as before.

I've tested this update with both small and large files:
Small file (README.md, ~6 KB) → progress jumps directly to 100%.
Large file (BIG_TEST.bin, 200 MB) → progress updates smoothly from 0% to 100% in one line.
Output formatting and CLI prompt behavior look correct in both cases.

I used ChatGPT and the updated project documentation to better understand Java console behavior (\r, flush()), and to learn how to implement update.
I've tested changes manually.

This is my first open-source pull request, and I really enjoyed learning through this project! 😊

