### PR TITLE
feat(server): log server configuration on startup using serverLogger

### DIFF
--- a/src/main/java/com/makaty/code/Server/Server.java
+++ b/src/main/java/com/makaty/code/Server/Server.java
@@ -40,14 +40,7 @@ public class Server {
 
         Server.serverLogger.info("Server started successfully.");
 
-        Server.serverLogger.info(String.format(
-                "Server info -> CommandHost: %s | CommandPort: %d | DataHost: %s | DataPort: %d | WorkerThreads: %d",
-                ServerConfig.COMMAND_HOST,
-                ServerConfig.COMMAND_PORT,
-                ServerConfig.DATA_HOST,
-                ServerConfig.DATA_PORT,
-                ServerConfig.WORKER_THREADS
-        ));
+        showServerInfo();
     }
 
     public void terminate() {
@@ -66,6 +59,17 @@ public class Server {
         Server.sessionRegistry.removeAll();
 
         serverLogger.info("Server terminated.");
+    }
+
+    private void showServerInfo() {
+        Server.serverLogger.info(String.format(
+                "Server info -> CommandHost: %s | CommandPort: %d | DataHost: %s | DataPort: %d | WorkerThreads: %d",
+                ServerConfig.COMMAND_HOST,
+                ServerConfig.COMMAND_PORT,
+                ServerConfig.DATA_HOST,
+                ServerConfig.DATA_PORT,
+                ServerConfig.WORKER_THREADS)
+        );
     }
 
 

--- a/src/main/java/com/makaty/code/Server/Server.java
+++ b/src/main/java/com/makaty/code/Server/Server.java
@@ -3,6 +3,7 @@ package com.makaty.code.Server;
 import com.makaty.code.Server.Loggers.ServerCLILogger;
 import com.makaty.code.Server.Loggers.ServerLogger;
 import com.makaty.code.Server.Models.CommandSelectorDispatcher;
+import com.makaty.code.Server.Models.ServerConfig;
 import com.makaty.code.Server.Registries.SessionRegistry;
 import com.makaty.code.Server.SocketAcceptors.CommandSocketAcceptor;
 import com.makaty.code.Server.SocketAcceptors.DataSocketAcceptor;
@@ -38,6 +39,15 @@ public class Server {
         selectorDispatcher.start();
 
         Server.serverLogger.info("Server started successfully.");
+
+        Server.serverLogger.info(String.format(
+                "Server info -> CommandHost: %s | CommandPort: %d | DataHost: %s | DataPort: %d | WorkerThreads: %d",
+                ServerConfig.COMMAND_HOST,
+                ServerConfig.COMMAND_PORT,
+                ServerConfig.DATA_HOST,
+                ServerConfig.DATA_PORT,
+                ServerConfig.WORKER_THREADS
+        ));
     }
 
     public void terminate() {


### PR DESCRIPTION
Hey 🙂
I added logging of CommandHost, CommandPort, DataHost, DataPort, and WorkerThreads using the existing Server.serverLogger.
Just wanted to check if this is the right direction — does it make sense to keep it here in Server.start(), or would you prefer it moved into a separate method like showServerInfo()?
Thanks!